### PR TITLE
fix: context not being provided to energy storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the Wireless Crafting Grid being unable to be charged on Fabric.
+
 ## [1.0.4] - 2025-08-05
 
 ### Fixed

--- a/refinedstorage-quartz-arsenal-fabric/src/main/java/com/refinedmods/refinedstorage/quartzarsenal/fabric/ModInitializerImpl.java
+++ b/refinedstorage-quartz-arsenal-fabric/src/main/java/com/refinedmods/refinedstorage/quartzarsenal/fabric/ModInitializerImpl.java
@@ -96,7 +96,7 @@ public class ModInitializerImpl extends AbstractModInitializer implements Refine
     private void registerEnergyItemProviders() {
         EnergyStorage.ITEM.registerForItems(
             (stack, context) ->
-                new EnergyStorageAdapter(Items.INSTANCE.getWirelessCraftingGrid().createEnergyStorage(stack)),
+                new EnergyStorageAdapter(Items.INSTANCE.getWirelessCraftingGrid().createEnergyStorage(stack), context),
             Items.INSTANCE.getWirelessCraftingGrid()
         );
     }


### PR DESCRIPTION
This fixes charging from mods such as Tech Reborn on Fabric.